### PR TITLE
Exclude dependabot PRs from Docker build step

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+    branches-ignore:
+      - dependabot/**
 
 jobs:
 


### PR DESCRIPTION
Dependabot doesn't have permissions to push packages, so exclude dependabot PRs from needing to build Docker images.